### PR TITLE
Add Runtime in Generated Markdown File

### DIFF
--- a/Utilities/generateGitHubMarkdown.js
+++ b/Utilities/generateGitHubMarkdown.js
@@ -19,6 +19,7 @@ var dependencies = {}
     markdownArray = []
 
 function generateMarkdown() {
+  markdownArray.push(`## Updated: ${now.format("LLL")}`)
   markdownArray.push('|**Repo**|**Title**|**Age**|')
   markdownArray.push('|:----|:----|:----|')
   for (dependency in dependencies) {


### PR DESCRIPTION
Resolves gh-3

This change adds a header with the time the markdown file is generated.