### PR TITLE
Sort output based on repository weight

### DIFF
--- a/findIssues.js
+++ b/findIssues.js
@@ -45,6 +45,9 @@ const finder = new mariner.IssueFinder(logger);
 
 function convertToRecord(issues) {
     const record = {};
+    repositoryIdentifiers
+        .sort((a, b) => countsByLibrary[b] - countsByLibrary[a])
+        .map(a => record[a] = [])
     issues.forEach((issuesForRepo, repo) => {
         record[repo] = issuesForRepo;
     });


### PR DESCRIPTION
Resolves gh-6

I assumed having a greather weight value means that it would be first in the output.