### PR TITLE
Add generateConfluenceMarkdown.js

### DIFF
--- a/OutputFiles/confluenceMarkdown.md
+++ b/OutputFiles/confluenceMarkdown.md
@@ -1,0 +1,31 @@
+h2. Updated: October 25, 2020 5:14 PM
+
+
+h3. indeedeng/k8dash
+||*Title*||*Age*||
+|["Filtering" should support permalinks|https://github.com/indeedeng/k8dash/issues/153]|21&nbsp;days|
+|[Fix styling of dropdown's in dark mode|https://github.com/indeedeng/k8dash/issues/152]|21&nbsp;days|
+|[Use "prefers-color-scheme" to automatically switch to Dark Mode|https://github.com/indeedeng/k8dash/issues/144]|23&nbsp;days|
+
+
+h3. indeedeng/starfish
+||*Title*||*Age*||
+|[Add configuration options to allow filtering of self-owned repositories|https://github.com/indeedeng/starfish/issues/65]|9&nbsp;days|
+|[replace Moment.js with Luxon|https://github.com/indeedeng/starfish/issues/60]|11&nbsp;days|
+|[Allow filtering based on action types within event types|https://github.com/indeedeng/starfish/issues/58]|12&nbsp;days|
+
+
+h3. depscloud/depscloud
+||*Title*||*Age*||
+|[Add support for jsonnet-bundler files|https://github.com/depscloud/depscloud/issues/115]|12&nbsp;days|
+|[Add support for prometheus push gateway to indexer|https://github.com/depscloud/depscloud/issues/108]|16&nbsp;days|
+
+
+h3. indeedeng/Mariner-Issue-Collector
+||*Title*||*Age*||
+|[Catalog potential sources of dependency information.|https://github.com/indeedeng/Mariner-Issue-Collector/issues/19]|3&nbsp;days|
+|[Create a convertFromWhiteSource.js utility|https://github.com/indeedeng/Mariner-Issue-Collector/issues/18]|3&nbsp;days|
+|[Create a generateConfluenceMarkdown.js utility|https://github.com/indeedeng/Mariner-Issue-Collector/issues/17]|3&nbsp;days|
+|[Create a simple generateHtml.js utility|https://github.com/indeedeng/Mariner-Issue-Collector/issues/16]|3&nbsp;days|
+|[Update gh-pages landing page to show found issues.|https://github.com/indeedeng/Mariner-Issue-Collector/issues/15]|3&nbsp;days|
+|[Update the readme to close documentation gaps.|https://github.com/indeedeng/Mariner-Issue-Collector/issues/2]|25&nbsp;days|

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ node Utilities/generateGitHubMarkdown.js
 
 This will parse the outputData.json file and update the [githubMarkdown](./OutputFiles/githubMarkdown.md) with a list of issues that can be easily viewed on GitHub.
 
+Or generate markdown for use in Confluence/Jira:
+
+```bash
+node Utilities/generateConfluenceMarkdown.js
+```
+
+In Jira, simply copy and paste the contents of [confluenceMarkdown](./OutputFiles/confluenceMarkdown.md) into the text mode of the editor.
+
 ## Mariner Issue Collector As A GitHub Action
 
 Mariner ships with a default GitHub Action that runs every 8 hours to generate a fresh issue list,

--- a/Utilities/generateConfluenceMarkdown.js
+++ b/Utilities/generateConfluenceMarkdown.js
@@ -1,0 +1,49 @@
+const fs = require('fs')
+      path = require('path')
+      moment = require('moment')
+
+const outputFilePath =
+    process.env.MARINER_OUTPUT_FILE_PATH ||
+    path.join(__dirname, '..', 'OutputFiles', 'outputData.json');
+const markdownFilePath =
+    process.env.MARINER_MARKDOWN_FILE_PATH ||
+    path.join(__dirname, '..', 'OutputFiles', 'confluenceMarkdown.md');
+
+const maxIssuesAge =
+    process.env.MARINER_MAX_ISSUES_AGE ||
+    30
+
+const now = moment()
+
+var dependencies = {}
+    markdownArray = []
+
+function generateMarkdown() {
+  markdownArray.push(`h2. Updated: ${now.format("LLL")}`)
+  for(dependency in dependencies) {
+    if (!dependencies[dependency].length) continue
+    markdownArray.push('\n')
+    markdownArray.push(`h3. ${dependency}`)
+    markdownArray.push('||*Title*||*Age*||')
+    for(issue in dependencies[dependency]) {
+      var issueAge = now.diff(moment(dependencies[dependency][issue].createdAt), 'days')
+      if (issueAge < maxIssuesAge) {
+        markdownArray.push(`|[${dependencies[dependency][issue].title}|${dependencies[dependency][issue].url}]|${issueAge}&nbsp;days|`);
+      }
+    }
+  }
+}
+
+fs.exists(outputFilePath, (exists) => {
+  if (exists) {
+    const contents = fs.readFileSync(outputFilePath, {
+        encoding: 'utf8',
+    })
+    dependencies = JSON.parse(contents)
+    generateMarkdown()
+    fs.writeFileSync(markdownFilePath, markdownArray.join('\n'))
+  } else {
+    console.error("Input file does not exist", outputFilePath)
+    return
+  }
+})


### PR DESCRIPTION
Addresses #17 

Added `generateConfluenceMarkdown.js` based on `generateGitHubMarkdown.js` , with Confluence/Jira-friendly markdown.

In Confluence, either the Github or Confluence-style markdown can be imported. Using the Confluence-style markdown will look like this:

![Screen Shot 2020-10-25 at 17 33 58](https://user-images.githubusercontent.com/22435517/97120883-6f45c800-16e8-11eb-9cb0-f9f2d11d9ea7.png)

In Jira, the generated markdown can be copy-pasted into the text mode of the editor, and it'll look like this:

![Screen Shot 2020-10-25 at 17 34 18](https://user-images.githubusercontent.com/22435517/97120899-871d4c00-16e8-11eb-8f2d-59fdb83aaea0.png)
